### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rake Cloud Native Buildpack
+# Paketo Buildpack for Rake
 
 ## `gcr.io/paketo-buildpacks/rake`
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/rake"
   id = "paketo-buildpacks/rake"
   keywords = ["ruby", "rake"]
-  name = "Paketo Rake Buildpack"
+  name = "Paketo Buildpack for Rake"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"


### PR DESCRIPTION
Renames 'Paketo Rake Buildpack' to 'Paketo Buildpack for Rake'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
